### PR TITLE
Erreur dans les noms des tableaux histoRecompense et histoLongeurEpisode

### DIFF
--- a/tp6-TD/CliffWalking-QLearning-Solution2.ipynb
+++ b/tp6-TD/CliffWalking-QLearning-Solution2.ipynb
@@ -309,8 +309,8 @@
     "verbose=0\n",
     "\n",
     "# liste des valeurs pour créer un graphique \n",
-    "histoRecompenseQ=[]\n",
-    "histoLongueurEpisodeQ=[]\n",
+    "histoRecompense=[]\n",
+    "histoLongueurEpisode=[]\n",
     "\n",
     "# Nombre d'essai\n",
     "max_iter=1000\n",
@@ -347,8 +347,8 @@
     "        S=S_\n",
     "        # ## A=A_\n",
     "\n",
-    "    histoRecompenseS.append(cumulR)\n",
-    "    histoLongueurEpisodeS.append(cumulA)"
+    "    histoRecompense.append(cumulR)\n",
+    "    histoLongueurEpisode.append(cumulA)"
    ]
   },
   {


### PR DESCRIPTION
Le nom utilé pour le graphique est  histoRecompense pas de Q ou de S 